### PR TITLE
Store intent in chat metadata

### DIFF
--- a/api/src/api/clients/couchbase.py
+++ b/api/src/api/clients/couchbase.py
@@ -211,6 +211,38 @@ class CouchbaseChatClient:
             logger.exception("Failed to add message.")
             raise
 
+    def update_chat_metadata(self, chat_id: str, metadata: Dict[str, Any]) -> bool:
+        """
+        Update metadata for an existing chat session.
+
+        Args:
+            chat_id: The UUID of the chat session
+            metadata: The new metadata for the chat session
+
+        Returns:
+            True if the metadata was updated, False otherwise
+        """
+        if not self.chats:
+            self.init()
+
+        try:
+            chat = self.get_chat(chat_id)
+            if not chat:
+                return False
+            
+            # Merge existing metadata with new metadata
+            current_metadata = chat.get("metadata", {})
+            metadata = {**current_metadata, **metadata}
+
+            # Update metadata
+            chat["metadata"] = metadata
+            self.chats.upsert(chat_id, chat)
+            logger.info(f"Updated metadata for chat {chat_id}")
+            return True
+        except Exception:
+            logger.exception("Failed to update chat metadata.")
+            raise
+
     def get_chat(self, chat_id: str) -> Optional[Dict[str, Any]]:
         """
         Get a chat session by ID.

--- a/api/src/api/routes.py
+++ b/api/src/api/routes.py
@@ -450,6 +450,9 @@ async def add_chat_message(
         analysis = process_message(opper, formatted_messages)
         response = bake_response(opper, formatted_messages, analysis)
 
+    # Update chat metadata with the latest intent
+    db.update_chat_metadata(chat_id, {"intent": analysis["intent"]})
+
     # Add assistant response to database
     (response_id, response_ts) = db.add_message(chat_id, "assistant", response)
 


### PR DESCRIPTION
So that it can be accessed at any point, to be able to determine if bot/agent has all info needed for a certain task/intent.

Future examples:
1.
> - "What is the last date to declare for tax return?" -> Intent: general_info. No more info needed, agent can complete task by answering
> - "The last day for tax return is xxx."

2.
> - "I want to update my address" -> Intent: address_change. Need authentication/authorization through BankID:
> - "Please open the BankID app and authenticate"
> - "Done" -> Intent: (still) address_change. Now need address (Street, zip code, and city).
> - "What is the address you want to change to?"
> - "Kungsgatan 1, 12345 Stockholm"